### PR TITLE
Fix heading typos in SharingHist

### DIFF
--- a/analysis/SharingHist.Rmd
+++ b/analysis/SharingHist.Rmd
@@ -50,7 +50,7 @@ standard.error <- maxbeta/maxz
 pm.mash.beta   <- pm.mash * standard.error
 ```
 
-# Histograms of sharing by magnitude
+## Histograms of sharing by magnitude
 
 Sharing by magnitude means that two eQTLs have similar effect size
 (within a factor of 2).
@@ -93,7 +93,7 @@ eQTL is shared by magnitude has a mode at 1. This is a subset of eQTLs
 that have much stronger effect in one tissue than in any other
 ("tissue-specific").
 
-## Histogram of sharing by magnitude
+## Histogram of sharing by sign
 
 Sharing by sign means that the eQTLs have the same sign of effect.
 

--- a/docs/SharingHist.html
+++ b/docs/SharingHist.html
@@ -631,8 +631,8 @@ pm.mash        &lt;- out$posterior.means
 standard.error &lt;- maxbeta/maxz
 pm.mash.beta   &lt;- pm.mash * standard.error</code></pre>
 </div>
-<div id="histograms-of-sharing-by-magnitude" class="section level1">
-<h1>Histograms of sharing by magnitude</h1>
+<div id="histograms-of-sharing-by-magnitude" class="section level2">
+<h2>Histograms of sharing by magnitude</h2>
 <p>Sharing by magnitude means that two eQTLs have similar effect size (within a factor of 2).</p>
 <p>The histograms below summarize sharing by magnitude across all tissues (left), tissues other than brain (middle), and brain tissues only (right).</p>
 <pre class="r"><code>sigmat &lt;- (lfsr &lt;= thresh)
@@ -693,8 +693,8 @@ Peter Carbonetto
 </table>
 <p></details></p>
 <p>Observe that the distribution of the number of tissues in which an eQTL is shared by magnitude has a mode at 1. This is a subset of eQTLs that have much stronger effect in one tissue than in any other (“tissue-specific”).</p>
-<div id="histogram-of-sharing-by-magnitude" class="section level2">
-<h2>Histogram of sharing by magnitude</h2>
+<div id="histogram-of-sharing-by-sign" class="section level2">
+<h2>Histogram of sharing by sign</h2>
 <p>Sharing by sign means that the eQTLs have the same sign of effect.</p>
 <p>The histograms below summarize sharing by sign across all tissues (left), tissues other than brain (middle), and brain tissues only (right).</p>
 <pre class="r"><code>sign.func &lt;- function (normeffectsize)


### PR DESCRIPTION
Fix minor typos in SharingHist.Rmd and SharingHist.html for the page called "Distribution of eQTL sharing across tissues"

1. Changed "Histogram of sharing by magnitude" from Heading 1 to Heading 2, matching the format of the other pages
2. Changed name of section heading on sign sharing from "Histogram of sharing by magnitude" to "Histogram of sharing by sign"